### PR TITLE
fix: avoid logging passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /creds/aws
 /creds/gcp
+.vscode

--- a/src/server/routers/admin.rs
+++ b/src/server/routers/admin.rs
@@ -18,11 +18,20 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use utoipa::ToSchema;
 
-#[derive(Debug, serde::Deserialize, ToSchema)]
+#[derive(serde::Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AdminLoginRequest {
     pub account: String,
     pub password: String,
+}
+
+impl std::fmt::Debug for AdminLoginRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdminLoginRequest")
+            .field("account", &self.account)
+            .field("password", &"***")
+            .finish()
+    }
 }
 
 #[derive(serde::Serialize, ToSchema)]


### PR DESCRIPTION
Right now we are exposing user passwords in the logs. With this this PR we redact the user password in the logs.