### PR TITLE
feat: improve generated openapi spec

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,12 +1,14 @@
 pub(crate) mod aws;
 pub(crate) mod gcp;
+
 mod postgres;
-use crate::config;
 use anyhow::Context;
 use anyhow::Result;
 use rusoto_credential::ProfileProvider;
 use sqlx::PgPool;
 use tame_gcs::signing::ServiceAccount;
+
+use crate::config;
 
 pub(crate) async fn new_pg_pool() -> Result<PgPool> {
     postgres::connect(&config::fetch::<String>("db_url")).await

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 mod fetcher;
-use crate::server::utilities::bootstrap::JwtKeys;
+
 use once_cell::sync::Lazy;
+
+use crate::server::utilities::bootstrap::JwtKeys;
 
 pub(crate) static AWS_PROFILE: &str = "default";
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,13 +5,15 @@ mod repositories;
 mod routers;
 mod services;
 pub(crate) mod utilities;
-use crate::bootstrap;
+
 use anyhow::Context;
 use anyhow::Result;
 use rusoto_credential::AwsCredentials;
 use rusoto_credential::ProvideAwsCredentials;
 use sqlx::PgPool;
 use tame_gcs::signing::ServiceAccount;
+
+use crate::bootstrap;
 
 pub struct Server {
     pg_pool: PgPool,

--- a/src/server/entities/account.rs
+++ b/src/server/entities/account.rs
@@ -1,7 +1,3 @@
-use crate::impl_i64_property;
-use crate::impl_string_property;
-use crate::impl_uuid_property;
-use crate::server::repositories::account::Repository;
 use anyhow::anyhow;
 use anyhow::Result;
 use argon2::password_hash::rand_core::OsRng;
@@ -17,12 +13,15 @@ use sqlx::PgPool;
 use uuid::Uuid;
 use validator::Validate;
 
+use crate::impl_i64_property;
+use crate::impl_string_property;
+use crate::impl_uuid_property;
+use crate::server::repositories::account::Repository;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Id {
     value: Uuid,
 }
-
-impl_uuid_property!(Id);
 
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Name {
@@ -30,15 +29,11 @@ pub struct Name {
     value: String,
 }
 
-impl_string_property!(Name);
-
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Email {
     #[validate(email)]
     value: String,
 }
-
-impl_string_property!(Email);
 
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Password {
@@ -46,15 +41,11 @@ pub struct Password {
     value: String,
 }
 
-impl_string_property!(Password);
-
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Namespace {
     #[validate(length(min = 1))]
     value: String,
 }
-
-impl_string_property!(Namespace);
 
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Ttl {
@@ -62,6 +53,11 @@ pub struct Ttl {
     value: i64,
 }
 
+impl_uuid_property!(Id);
+impl_string_property!(Name);
+impl_string_property!(Email);
+impl_string_property!(Password);
+impl_string_property!(Namespace);
 impl_i64_property!(Ttl);
 
 #[derive(Debug, Clone, PartialEq, Eq, Getters, Setters)]

--- a/src/server/entities/schema.rs
+++ b/src/server/entities/schema.rs
@@ -17,15 +17,11 @@ pub struct Id {
     value: Uuid,
 }
 
-impl_uuid_property!(Id);
-
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Name {
     #[validate(length(min = 1))]
     value: String,
 }
-
-impl_string_property!(Name);
 
 #[derive(Debug, Clone, PartialEq, Eq, Getters, Setters)]
 pub struct Entity {
@@ -38,6 +34,9 @@ pub struct Entity {
     #[getset(get = "pub")]
     created_by: AccountId,
 }
+
+impl_uuid_property!(Id);
+impl_string_property!(Name);
 
 impl Entity {
     pub fn new(

--- a/src/server/entities/share.rs
+++ b/src/server/entities/share.rs
@@ -1,7 +1,3 @@
-use crate::impl_string_property;
-use crate::impl_uuid_property;
-use crate::server::entities::account::Id as AccountId;
-use crate::server::repositories::share::Repository;
 use anyhow::Result;
 use getset::Getters;
 use getset::Setters;
@@ -10,12 +6,15 @@ use sqlx::PgPool;
 use uuid::Uuid;
 use validator::Validate;
 
+use crate::impl_string_property;
+use crate::impl_uuid_property;
+use crate::server::entities::account::Id as AccountId;
+use crate::server::repositories::share::Repository;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Id {
     value: Uuid,
 }
-
-impl_uuid_property!(Id);
 
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Name {
@@ -23,6 +22,7 @@ pub struct Name {
     value: String,
 }
 
+impl_uuid_property!(Id);
 impl_string_property!(Name);
 
 #[derive(Debug, Clone, PartialEq, Eq, Getters, Setters)]

--- a/src/server/entities/table.rs
+++ b/src/server/entities/table.rs
@@ -17,15 +17,11 @@ pub struct Id {
     value: Uuid,
 }
 
-impl_uuid_property!(Id);
-
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Name {
     #[validate(length(min = 1))]
     value: String,
 }
-
-impl_string_property!(Name);
 
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Location {
@@ -33,6 +29,8 @@ pub struct Location {
     value: String,
 }
 
+impl_uuid_property!(Id);
+impl_string_property!(Name);
 impl_string_property!(Location);
 
 #[derive(Debug, Clone, PartialEq, Eq, Getters, Setters)]

--- a/src/server/entities/token.rs
+++ b/src/server/entities/token.rs
@@ -1,8 +1,3 @@
-use crate::impl_string_property;
-use crate::impl_uuid_property;
-use crate::server::entities::account::Id as AccountId;
-use crate::server::middlewares::jwt::Role;
-use crate::server::repositories::token::Repository;
 use anyhow::Result;
 use getset::Getters;
 use getset::Setters;
@@ -11,12 +6,16 @@ use sqlx::PgPool;
 use uuid::Uuid;
 use validator::Validate;
 
+use crate::impl_string_property;
+use crate::impl_uuid_property;
+use crate::server::entities::account::Id as AccountId;
+use crate::server::middlewares::jwt::Role;
+use crate::server::repositories::token::Repository;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Id {
     value: Uuid,
 }
-
-impl_uuid_property!(Id);
 
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Email {
@@ -24,14 +23,14 @@ pub struct Email {
     value: String,
 }
 
-impl_string_property!(Email);
-
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Value {
     #[validate(length(min = 1))]
     value: String,
 }
 
+impl_uuid_property!(Id);
+impl_string_property!(Email);
 impl_string_property!(Value);
 
 #[derive(Debug, Clone, PartialEq, Eq, Getters, Setters)]

--- a/src/server/repositories/account.rs
+++ b/src/server/repositories/account.rs
@@ -1,12 +1,13 @@
-use crate::server::entities::account::Entity;
-use crate::server::entities::account::Name;
-use crate::server::utilities::postgres::PgAcquire;
 use anyhow::Context;
 use anyhow::Result;
 use chrono::DateTime;
 use chrono::Utc;
 use sqlx::postgres::PgQueryResult;
 use uuid::Uuid;
+
+use crate::server::entities::account::Entity;
+use crate::server::entities::account::Name;
+use crate::server::utilities::postgres::PgAcquire;
 
 #[derive(Debug, Clone, serde::Serialize, sqlx::FromRow)]
 pub struct Row {

--- a/src/server/repositories/schema.rs
+++ b/src/server/repositories/schema.rs
@@ -1,16 +1,15 @@
-#![allow(unused)]
-use crate::server::entities::schema::Entity;
-use crate::server::entities::schema::Id;
-use crate::server::entities::schema::Name;
-use crate::server::entities::share::Id as ShareId;
-use crate::server::entities::table::Id as TableId;
-use crate::server::utilities::postgres::PgAcquire;
 use anyhow::Context;
 use anyhow::Result;
 use chrono::DateTime;
 use chrono::Utc;
 use sqlx::postgres::PgQueryResult;
 use uuid::Uuid;
+
+use crate::server::entities::schema::Entity;
+use crate::server::entities::schema::Name;
+use crate::server::entities::share::Id as ShareId;
+
+use crate::server::utilities::postgres::PgAcquire;
 
 #[derive(Debug, Clone, serde::Serialize, sqlx::FromRow)]
 pub struct Row {
@@ -89,19 +88,17 @@ impl Repository {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::server::entities::account::Entity as Account;
-    use crate::server::entities::account::Id as AccountId;
-    use crate::server::entities::schema::Entity as Schema;
-    use crate::server::entities::share::Entity as Share;
-    use crate::server::repositories::account::Repository as AccountRepository;
-    use crate::server::repositories::schema::Repository as SchemaRepository;
-    use crate::server::repositories::share::Repository as ShareRepository;
     use anyhow::Context;
     use anyhow::Result;
     use sqlx::PgConnection;
     use sqlx::PgPool;
-    use std::cmp::min;
+
+    use super::*;
+    use crate::server::entities::account::Entity as Account;
+    use crate::server::entities::account::Id as AccountId;
+    use crate::server::entities::share::Entity as Share;
+    use crate::server::repositories::account::Repository as AccountRepository;
+    use crate::server::repositories::share::Repository as ShareRepository;
 
     async fn create_account(tx: &mut PgConnection) -> Result<Account> {
         let account = Account::new(
@@ -118,20 +115,6 @@ mod tests {
             .context("failed to create account")?;
         Ok(account)
     }
-
-    // async fn create_schema(account_id: &AccountId, tx: &mut PgConnection) -> Result<Schema> {
-    //     let schema = Schema::new(
-    //         testutils::rand::uuid(),
-    //         testutils::rand::string(10),
-    //         testutils::rand::string(10),
-    //         account_id.to_uuid().to_string(),
-    //     )
-    //     .context("failed to validate table")?;
-    //     SchemaRepository::upsert(&schema, tx)
-    //         .await
-    //         .context("failed to create table")?;
-    //     Ok(schema)
-    // }
 
     async fn create_share(account_id: &AccountId, tx: &mut PgConnection) -> Result<Share> {
         let share = Share::new(

--- a/src/server/repositories/share.rs
+++ b/src/server/repositories/share.rs
@@ -1,12 +1,13 @@
-use crate::server::entities::share::Entity;
-use crate::server::entities::share::Name;
-use crate::server::utilities::postgres::PgAcquire;
 use anyhow::Context;
 use anyhow::Result;
 use chrono::DateTime;
 use chrono::Utc;
 use sqlx::postgres::PgQueryResult;
 use uuid::Uuid;
+
+use crate::server::entities::share::Entity;
+use crate::server::entities::share::Name;
+use crate::server::utilities::postgres::PgAcquire;
 
 #[derive(Debug, Clone, serde::Serialize, sqlx::FromRow)]
 pub struct Row {

--- a/src/server/repositories/table.rs
+++ b/src/server/repositories/table.rs
@@ -1,12 +1,13 @@
-use crate::server::entities::table::Entity;
-use crate::server::entities::table::Name;
-use crate::server::utilities::postgres::PgAcquire;
 use anyhow::Context;
 use anyhow::Result;
 use chrono::DateTime;
 use chrono::Utc;
 use sqlx::postgres::PgQueryResult;
 use uuid::Uuid;
+
+use crate::server::entities::table::Entity;
+use crate::server::entities::table::Name;
+use crate::server::utilities::postgres::PgAcquire;
 
 #[derive(Debug, Clone, serde::Serialize, sqlx::FromRow)]
 pub struct Row {

--- a/src/server/repositories/token.rs
+++ b/src/server/repositories/token.rs
@@ -1,12 +1,13 @@
-use crate::server::entities::token::Entity;
-use crate::server::middlewares::jwt::Role;
-use crate::server::utilities::postgres::PgAcquire;
 use anyhow::Context;
 use anyhow::Result;
 use chrono::DateTime;
 use chrono::Utc;
 use sqlx::postgres::PgQueryResult;
 use uuid::Uuid;
+
+use crate::server::entities::token::Entity;
+use crate::server::middlewares::jwt::Role;
+use crate::server::utilities::postgres::PgAcquire;
 
 #[derive(Debug, Clone, serde::Serialize, sqlx::FromRow)]
 pub struct Row {

--- a/src/server/routers/admin.rs
+++ b/src/server/routers/admin.rs
@@ -42,6 +42,7 @@ pub struct AdminLoginResponse {
 #[utoipa::path(
     post,
     path = "/admin/login",
+    tag = "admin",
     request_body = AdminLoginRequest,
     responses(
         (status = 200, description = "The profile was successfully returned.", body = AdminLoginResponse),

--- a/src/server/routers/admin.rs
+++ b/src/server/routers/admin.rs
@@ -1,5 +1,11 @@
-pub mod accounts;
-pub mod shares;
+use anyhow::anyhow;
+use axum::extract::Extension;
+use axum::extract::Json;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::response::Response;
+use utoipa::ToSchema;
+
 use crate::server::entities::account::Entity as AccountEntity;
 use crate::server::entities::account::Name as AccountName;
 use crate::server::entities::token::Entity as TokenEntity;
@@ -9,13 +15,9 @@ use crate::server::services::error::Error;
 use crate::server::services::profile::Profile;
 use crate::server::services::profile::Service as ProfileService;
 use crate::server::utilities::postgres::Utility as PostgresUtility;
-use anyhow::anyhow;
-use axum::extract::Extension;
-use axum::extract::Json;
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
-use axum::response::Response;
-use utoipa::ToSchema;
+
+pub mod accounts;
+pub mod shares;
 
 #[derive(serde::Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]

--- a/src/server/routers/admin/accounts.rs
+++ b/src/server/routers/admin/accounts.rs
@@ -1,10 +1,3 @@
-use crate::server::entities::account::Entity as AccountEntity;
-use crate::server::entities::account::Name as AccountName;
-use crate::server::routers::SharedState;
-use crate::server::services::account::Account;
-use crate::server::services::account::Service as AccountService;
-use crate::server::services::error::Error;
-use crate::server::utilities::postgres::Utility as PostgresUtility;
 use anyhow::anyhow;
 use axum::extract::Extension;
 use axum::extract::Json;
@@ -15,6 +8,14 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
+
+use crate::server::entities::account::Entity as AccountEntity;
+use crate::server::entities::account::Name as AccountName;
+use crate::server::routers::SharedState;
+use crate::server::services::account::Account;
+use crate::server::services::account::Service as AccountService;
+use crate::server::services::error::Error;
+use crate::server::utilities::postgres::Utility as PostgresUtility;
 
 const DEFAULT_PAGE_RESULTS: usize = 10;
 

--- a/src/server/routers/admin/accounts.rs
+++ b/src/server/routers/admin/accounts.rs
@@ -38,6 +38,8 @@ pub struct AdminAccountsPostResponse {
 #[utoipa::path(
     post,
     path = "/admin/accounts",
+    operation_id = "CreateAccount",
+    tag = "admin",
     request_body = AdminAccountsPostRequest,
     responses(
         (status = 201, description = "The account was successfully registered.", body = AdminAccountsPostResponse),
@@ -102,9 +104,9 @@ pub struct AdminAccountsGetResponse {
 #[utoipa::path(
     get,
     path = "/admin/accounts/{account}",
-    params(
-        AdminAccountsGetParams,
-    ),
+    operation_id = "GetAccount",
+    tag = "admin",
+    params(AdminAccountsGetParams),
     responses(
         (status = 200, description = "The account's metadata was successfully returned.", body = AdminAccountsGetResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
@@ -155,9 +157,9 @@ pub struct AdminAccountsListResponse {
 #[utoipa::path(
     get,
     path = "/admin/accounts",
-    params(
-        AdminAccountsListQuery,
-    ),
+    operation_id = "ListAccounts",
+    tag = "admin",
+    params(AdminAccountsListQuery),
     responses(
         (status = 200, description = "The accounts were successfully returned.", body = AdminAccountsListResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),

--- a/src/server/routers/admin/shares.rs
+++ b/src/server/routers/admin/shares.rs
@@ -1,10 +1,3 @@
-pub mod schemas;
-use crate::server::entities::account::Entity as AccountEntity;
-use crate::server::entities::share::Entity as ShareEntity;
-use crate::server::routers::SharedState;
-use crate::server::services::error::Error;
-use crate::server::services::share::Share;
-use crate::server::utilities::postgres::Utility as PostgresUtility;
 use anyhow::anyhow;
 use axum::extract::Extension;
 use axum::extract::Json;
@@ -12,6 +5,15 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
 use utoipa::ToSchema;
+
+use crate::server::entities::account::Entity as AccountEntity;
+use crate::server::entities::share::Entity as ShareEntity;
+use crate::server::routers::SharedState;
+use crate::server::services::error::Error;
+use crate::server::services::share::Share;
+use crate::server::utilities::postgres::Utility as PostgresUtility;
+
+pub mod schemas;
 
 #[derive(Debug, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]

--- a/src/server/routers/admin/shares.rs
+++ b/src/server/routers/admin/shares.rs
@@ -28,6 +28,8 @@ pub struct AdminSharesPostResponse {
 #[utoipa::path(
     post,
     path = "/admin/shares",
+    operation_id = "CreateShare",
+    tag = "admin",
     request_body = AdminSharesPostRequest,
     responses(
         (status = 201, description = "The share was successfully registered.", body = AdminSharesPostResponse),

--- a/src/server/routers/admin/shares/schemas.rs
+++ b/src/server/routers/admin/shares/schemas.rs
@@ -40,10 +40,10 @@ pub struct AdminSharesSchemasPostResponse {
 
 #[utoipa::path(
     post,
-    path = "admin/shares/{share}/schemas",
-    params(
-        AdminSharesSchemasPostParams,
-    ),
+    path = "/admin/shares/{share}/schemas",
+    operation_id = "CreateSchema",
+    tag = "admin",
+    params(AdminSharesSchemasPostParams),
     request_body = AdminSharesSchemasPostRequest,
     responses(
         (status = 201, description = "The schema was successfully registered.", body = AdminSharesSchemasPostResponse),

--- a/src/server/routers/admin/shares/schemas.rs
+++ b/src/server/routers/admin/shares/schemas.rs
@@ -72,7 +72,7 @@ pub async fn post(
     };
     let Some(share) = maybe_share else {
         tracing::error!("share was not found");
-        return Err(Error::BadRequest);
+        return Err(Error::NotFound);
     };
     let Ok(schema_name) = SchemaName::new(payload.name) else {
         tracing::error!("schema name is malformed");

--- a/src/server/routers/admin/shares/schemas/tables.rs
+++ b/src/server/routers/admin/shares/schemas/tables.rs
@@ -42,10 +42,10 @@ pub struct AdminSharesSchemasTablesPostResponse {
 
 #[utoipa::path(
     post,
-    path = "admin/shares/{share}/schemas/{schema}/tables",
-    params(
-        AdminSharesSchemasTablesPostParams,
-    ),
+    path = "/admin/shares/{share}/schemas/{schema}/tables",
+    operation_id = "CreateTable",
+    tag = "admin",
+    params(AdminSharesSchemasTablesPostParams),
     request_body = AdminSharesSchemasTablesPostRequest,
     responses(
         (status = 201, description = "The schema was successfully registered.", body = AdminSharesSchemasTablesPostResponse),

--- a/src/server/routers/admin/shares/schemas/tables.rs
+++ b/src/server/routers/admin/shares/schemas/tables.rs
@@ -74,7 +74,7 @@ pub async fn post(
     };
     let Some(share) = maybe_share else {
         tracing::error!("share was not found");
-        return Err(Error::BadRequest);
+        return Err(Error::NotFound);
     };
     let Ok(schema_name) = SchemaName::new(params.schema) else {
         tracing::error!("requested share data is malformed");
@@ -89,7 +89,7 @@ pub async fn post(
     };
     let Some(schema) = maybe_schema else {
         tracing::error!("share was not found");
-        return Err(Error::BadRequest);
+        return Err(Error::NotFound);
     };
     let Ok(table_name) = TableName::new(payload.name) else {
         tracing::error!("requested table data is malformed");

--- a/src/server/routers/shares.rs
+++ b/src/server/routers/shares.rs
@@ -33,9 +33,9 @@ pub struct SharesGetResponse {
 #[utoipa::path(
     get,
     path = "/shares/{share}",
-    params(
-        SharesGetParams,
-    ),
+    tag = "official",
+    operation_id = "GetShare",
+    params(SharesGetParams),
     responses(
         (status = 200, description = "The share's metadata was successfully returned.", body = SharesGetResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
@@ -86,9 +86,9 @@ pub struct SharesListResponse {
 #[utoipa::path(
     get,
     path = "/shares",
-    params(
-        SharesListQuery,
-    ),
+    operation_id = "ListShares",
+    tag = "official",
+    params(SharesListQuery),
     responses(
         (status = 200, description = "The shares were successfully returned.", body = SharesListResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),

--- a/src/server/routers/shares.rs
+++ b/src/server/routers/shares.rs
@@ -1,10 +1,3 @@
-pub mod all_tables;
-pub mod schemas;
-use crate::server::entities::share::Name as ShareName;
-use crate::server::routers::SharedState;
-use crate::server::services::error::Error;
-use crate::server::services::share::Service as ShareService;
-use crate::server::services::share::Share;
 use anyhow::anyhow;
 use axum::extract::Extension;
 use axum::extract::Json;
@@ -15,6 +8,15 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
+
+use crate::server::entities::share::Name as ShareName;
+use crate::server::routers::SharedState;
+use crate::server::services::error::Error;
+use crate::server::services::share::Service as ShareService;
+use crate::server::services::share::Share;
+
+pub mod all_tables;
+pub mod schemas;
 
 const DEFAULT_PAGE_RESULTS: usize = 10;
 

--- a/src/server/routers/shares/all_tables.rs
+++ b/src/server/routers/shares/all_tables.rs
@@ -42,7 +42,10 @@ pub struct SharesAllTablesListResponse {
 #[utoipa::path(
     get,
     path = "/shares/{share}/all-tables",
+    operation_id = "ListALLTables",
+    tag = "official",
     params(
+        SharesAllTablesListParams,
         SharesAllTablesListQuery,
     ),
     responses(

--- a/src/server/routers/shares/all_tables.rs
+++ b/src/server/routers/shares/all_tables.rs
@@ -1,10 +1,3 @@
-use crate::server::entities::share::Entity as ShareEntity;
-use crate::server::entities::share::Name as ShareName;
-use crate::server::entities::table::Name as TableName;
-use crate::server::routers::SharedState;
-use crate::server::services::error::Error;
-use crate::server::services::table::Service as TableService;
-use crate::server::services::table::TableDetail;
 use anyhow::anyhow;
 use axum::extract::Extension;
 use axum::extract::Json;
@@ -15,6 +8,14 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
+
+use crate::server::entities::share::Entity as ShareEntity;
+use crate::server::entities::share::Name as ShareName;
+use crate::server::entities::table::Name as TableName;
+use crate::server::routers::SharedState;
+use crate::server::services::error::Error;
+use crate::server::services::table::Service as TableService;
+use crate::server::services::table::TableDetail;
 
 const DEFAULT_PAGE_RESULTS: usize = 10;
 

--- a/src/server/routers/shares/schemas.rs
+++ b/src/server/routers/shares/schemas.rs
@@ -1,11 +1,3 @@
-pub mod tables;
-use crate::server::entities::schema::Name as SchemaName;
-use crate::server::entities::share::Entity as ShareEntity;
-use crate::server::entities::share::Name as ShareName;
-use crate::server::routers::SharedState;
-use crate::server::services::error::Error;
-use crate::server::services::schema::SchemaDetail;
-use crate::server::services::schema::Service as SchemaService;
 use anyhow::anyhow;
 use axum::extract::Extension;
 use axum::extract::Json;
@@ -16,6 +8,16 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
+
+use crate::server::entities::schema::Name as SchemaName;
+use crate::server::entities::share::Entity as ShareEntity;
+use crate::server::entities::share::Name as ShareName;
+use crate::server::routers::SharedState;
+use crate::server::services::error::Error;
+use crate::server::services::schema::SchemaDetail;
+use crate::server::services::schema::Service as SchemaService;
+
+pub mod tables;
 
 const DEFAULT_PAGE_RESULTS: usize = 10;
 

--- a/src/server/routers/shares/schemas.rs
+++ b/src/server/routers/shares/schemas.rs
@@ -43,7 +43,10 @@ pub struct SharesSchemasListResponse {
 #[utoipa::path(
     get,
     path = "/shares/{share}/schemas",
+    operation_id = "ListSchemas",
+    tag = "official",
     params(
+        SharesSchemasListParams,
         SharesSchemasListQuery,
     ),
     responses(

--- a/src/server/routers/shares/schemas/tables.rs
+++ b/src/server/routers/shares/schemas/tables.rs
@@ -47,7 +47,10 @@ pub struct SharesSchemasTablesListResponse {
 #[utoipa::path(
     get,
     path = "/shares/{share}/schemas/{schema}/tables",
+    operation_id = "ListTables",
+    tag = "official",
     params(
+        SharesSchemasTablesListParams,
         SharesSchemasTablesListQuery,
     ),
     responses(

--- a/src/server/routers/shares/schemas/tables.rs
+++ b/src/server/routers/shares/schemas/tables.rs
@@ -1,14 +1,3 @@
-pub mod metadata;
-pub mod query;
-pub mod version;
-use crate::server::entities::schema::Name as SchemaName;
-use crate::server::entities::share::Entity as ShareEntity;
-use crate::server::entities::share::Name as ShareName;
-use crate::server::entities::table::Name as TableName;
-use crate::server::routers::SharedState;
-use crate::server::services::error::Error;
-use crate::server::services::table::Service as TableService;
-use crate::server::services::table::TableDetail;
 use anyhow::anyhow;
 use axum::extract::Extension;
 use axum::extract::Json;
@@ -19,6 +8,19 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
+
+use crate::server::entities::schema::Name as SchemaName;
+use crate::server::entities::share::Entity as ShareEntity;
+use crate::server::entities::share::Name as ShareName;
+use crate::server::entities::table::Name as TableName;
+use crate::server::routers::SharedState;
+use crate::server::services::error::Error;
+use crate::server::services::table::Service as TableService;
+use crate::server::services::table::TableDetail;
+
+pub mod metadata;
+pub mod query;
+pub mod version;
 
 const DEFAULT_PAGE_RESULTS: usize = 10;
 

--- a/src/server/routers/shares/schemas/tables/metadata.rs
+++ b/src/server/routers/shares/schemas/tables/metadata.rs
@@ -31,6 +31,9 @@ pub struct SharesSchemasTablesMetadataGetParams {
 #[utoipa::path(
     get,
     path = "/shares/{share}/schemas/{schema}/tables/{table}/metadata",
+    operation_id = "GetTableMetadata",
+    tag = "official",
+    params(SharesSchemasTablesMetadataGetParams),
     responses(
         (status = 200, description = "The table metadata was successfully returned.", body = String),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),

--- a/src/server/routers/shares/schemas/tables/metadata.rs
+++ b/src/server/routers/shares/schemas/tables/metadata.rs
@@ -1,11 +1,3 @@
-use crate::server::entities::schema::Name as SchemaName;
-use crate::server::entities::share::Name as ShareName;
-use crate::server::entities::table::Name as TableName;
-use crate::server::routers::SharedState;
-use crate::server::services::deltalake::Service as DeltalakeService;
-use crate::server::services::error::Error;
-use crate::server::services::table::Service as TableService;
-use crate::server::utilities::deltalake::Utility as DeltalakeUtility;
 use anyhow::anyhow;
 use axum::extract::Extension;
 use axum::extract::Path;
@@ -17,6 +9,15 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use axum_extra::json_lines::JsonLines;
 use utoipa::IntoParams;
+
+use crate::server::entities::schema::Name as SchemaName;
+use crate::server::entities::share::Name as ShareName;
+use crate::server::entities::table::Name as TableName;
+use crate::server::routers::SharedState;
+use crate::server::services::deltalake::Service as DeltalakeService;
+use crate::server::services::error::Error;
+use crate::server::services::table::Service as TableService;
+use crate::server::utilities::deltalake::Utility as DeltalakeUtility;
 
 const HEADER_NAME: &str = "Delta-Table-Version";
 

--- a/src/server/routers/shares/schemas/tables/query.rs
+++ b/src/server/routers/shares/schemas/tables/query.rs
@@ -52,7 +52,10 @@ pub struct SharesSchemasTablesQueryPostParams {
 #[utoipa::path(
     post,
     path = "/shares/{share}/schemas/{schema}/tables/{table}/query",
+    operation_id = "QueryTable",
+    tag = "official",
     request_body = SharesSchemasTablesQueryPostRequest,
+    params(SharesSchemasTablesQueryPostParams),
     responses(
         (status = 200, description = "The tables were successfully returned.", body = String),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),

--- a/src/server/routers/shares/schemas/tables/query.rs
+++ b/src/server/routers/shares/schemas/tables/query.rs
@@ -1,3 +1,18 @@
+use anyhow::anyhow;
+use axum::extract::Extension;
+use axum::extract::Json;
+use axum::extract::Path;
+use axum::http::header;
+use axum::http::header::HeaderMap;
+use axum::http::header::HeaderValue;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::response::Response;
+use axum_extra::json_lines::JsonLines;
+use std::str::FromStr;
+use utoipa::IntoParams;
+use utoipa::ToSchema;
+
 use crate::config;
 use crate::server::entities::schema::Name as SchemaName;
 use crate::server::entities::share::Name as ShareName;
@@ -14,20 +29,6 @@ use crate::server::utilities::signed_url::Platform;
 use crate::server::utilities::signed_url::Utility as SignedUrlUtility;
 use crate::server::utilities::sql::PartitionFilter as SQLPartitionFilter;
 use crate::server::utilities::sql::Utility as SQLUtility;
-use anyhow::anyhow;
-use axum::extract::Extension;
-use axum::extract::Json;
-use axum::extract::Path;
-use axum::http::header;
-use axum::http::header::HeaderMap;
-use axum::http::header::HeaderValue;
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
-use axum::response::Response;
-use axum_extra::json_lines::JsonLines;
-use std::str::FromStr;
-use utoipa::IntoParams;
-use utoipa::ToSchema;
 
 const HEADER_NAME: &str = "Delta-Table-Version";
 

--- a/src/server/routers/shares/schemas/tables/version.rs
+++ b/src/server/routers/shares/schemas/tables/version.rs
@@ -1,10 +1,3 @@
-use crate::server::entities::schema::Name as SchemaName;
-use crate::server::entities::share::Name as ShareName;
-use crate::server::entities::table::Name as TableName;
-use crate::server::routers::SharedState;
-use crate::server::services::error::Error;
-use crate::server::services::table::Service as TableService;
-use crate::server::utilities::deltalake::Utility as DeltalakeUtility;
 use anyhow::anyhow;
 use axum::extract::Extension;
 use axum::extract::Path;
@@ -14,6 +7,14 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
 use utoipa::IntoParams;
+
+use crate::server::entities::schema::Name as SchemaName;
+use crate::server::entities::share::Name as ShareName;
+use crate::server::entities::table::Name as TableName;
+use crate::server::routers::SharedState;
+use crate::server::services::error::Error;
+use crate::server::services::table::Service as TableService;
+use crate::server::utilities::deltalake::Utility as DeltalakeUtility;
 
 const HEADER_NAME: &str = "Delta-Table-Version";
 

--- a/src/server/routers/shares/schemas/tables/version.rs
+++ b/src/server/routers/shares/schemas/tables/version.rs
@@ -34,6 +34,9 @@ pub struct SharesSchemasTablesVersionGetQuery {
 #[utoipa::path(
     get,
     path = "/shares/{share}/schemas/{schema}/tables/{table}/version",
+    operation_id = "GetTableVersion",
+    tag = "official",
+    params(SharesSchemasTablesVersionGetParams),
     responses(
         (status = 200, description = "The table version was successfully returned."),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),

--- a/src/server/services/account.rs
+++ b/src/server/services/account.rs
@@ -1,11 +1,12 @@
-use crate::server::entities::account::Entity as AccountEntity;
-use crate::server::entities::account::Name as AccountName;
-use crate::server::utilities::postgres::PgAcquire;
 use anyhow::Context;
 use anyhow::Result;
 use sqlx::query_builder::QueryBuilder;
 use sqlx::Execute;
 use utoipa::ToSchema;
+
+use crate::server::entities::account::Entity as AccountEntity;
+use crate::server::entities::account::Name as AccountName;
+use crate::server::utilities::postgres::PgAcquire;
 
 #[derive(Debug, Clone, serde::Serialize, sqlx::FromRow, ToSchema)]
 #[serde(rename_all = "camelCase")]

--- a/src/server/services/deltalake.rs
+++ b/src/server/services/deltalake.rs
@@ -1,8 +1,5 @@
-use crate::server::utilities::deltalake::Utility as DeltalakeUtility;
-use crate::server::utilities::json::PartitionFilter as JSONPartitionFilter;
-use crate::server::utilities::json::Utility as JSONUtility;
-use crate::server::utilities::sql::PartitionFilter as SQLPartitionFilter;
-use crate::server::utilities::sql::Utility as SQLUtility;
+use std::collections::HashMap;
+
 use anyhow::Result;
 use axum::BoxError;
 use deltalake::action::Add;
@@ -12,8 +9,13 @@ use deltalake::schema::Schema;
 use futures_util::stream::Stream;
 use md5;
 use serde_json::json;
-use std::collections::HashMap;
 use utoipa::ToSchema;
+
+use crate::server::utilities::deltalake::Utility as DeltalakeUtility;
+use crate::server::utilities::json::PartitionFilter as JSONPartitionFilter;
+use crate::server::utilities::json::Utility as JSONUtility;
+use crate::server::utilities::sql::PartitionFilter as SQLPartitionFilter;
+use crate::server::utilities::sql::Utility as SQLUtility;
 
 pub const VERSION: i32 = 1;
 

--- a/src/server/services/profile.rs
+++ b/src/server/services/profile.rs
@@ -1,7 +1,7 @@
-use crate::config;
-use crate::config::JWT_SECRET;
-use crate::server::middlewares::jwt::Claims;
-use crate::server::middlewares::jwt::Role;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
 use anyhow::Context;
 use anyhow::Result;
 use chrono::DateTime;
@@ -9,10 +9,12 @@ use chrono::NaiveDateTime;
 use chrono::Utc;
 use jsonwebtoken::encode;
 use jsonwebtoken::Header;
-use std::time::Duration;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 use utoipa::ToSchema;
+
+use crate::config;
+use crate::config::JWT_SECRET;
+use crate::server::middlewares::jwt::Claims;
+use crate::server::middlewares::jwt::Role;
 
 pub const VERSION: i32 = 1;
 

--- a/src/server/services/schema.rs
+++ b/src/server/services/schema.rs
@@ -1,12 +1,13 @@
-use crate::server::entities::schema::Entity as SchemaEntity;
-use crate::server::entities::schema::Name as SchemaName;
-use crate::server::entities::share::Name as ShareName;
-use crate::server::utilities::postgres::PgAcquire;
 use anyhow::Context;
 use anyhow::Result;
 use sqlx::query_builder::QueryBuilder;
 use sqlx::Execute;
 use utoipa::ToSchema;
+
+use crate::server::entities::schema::Entity as SchemaEntity;
+use crate::server::entities::schema::Name as SchemaName;
+use crate::server::entities::share::Name as ShareName;
+use crate::server::utilities::postgres::PgAcquire;
 
 #[derive(Debug, Clone, serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]

--- a/src/server/services/share.rs
+++ b/src/server/services/share.rs
@@ -1,11 +1,12 @@
-use crate::server::entities::share::Entity as ShareEntity;
-use crate::server::entities::share::Name as ShareName;
-use crate::server::utilities::postgres::PgAcquire;
 use anyhow::Context;
 use anyhow::Result;
 use sqlx::query_builder::QueryBuilder;
 use sqlx::Execute;
 use utoipa::ToSchema;
+
+use crate::server::entities::share::Entity as ShareEntity;
+use crate::server::entities::share::Name as ShareName;
+use crate::server::utilities::postgres::PgAcquire;
 
 #[derive(Debug, Clone, serde::Serialize, sqlx::FromRow, ToSchema)]
 #[serde(rename_all = "camelCase")]

--- a/src/server/services/table.rs
+++ b/src/server/services/table.rs
@@ -1,13 +1,14 @@
-use crate::server::entities::schema::Name as SchemaName;
-use crate::server::entities::share::Name as ShareName;
-use crate::server::entities::table::Entity as TableEntity;
-use crate::server::entities::table::Name as TableName;
-use crate::server::utilities::postgres::PgAcquire;
 use anyhow::Context;
 use anyhow::Result;
 use sqlx::query_builder::QueryBuilder;
 use sqlx::Execute;
 use utoipa::ToSchema;
+
+use crate::server::entities::schema::Name as SchemaName;
+use crate::server::entities::share::Name as ShareName;
+use crate::server::entities::table::Entity as TableEntity;
+use crate::server::entities::table::Name as TableName;
+use crate::server::utilities::postgres::PgAcquire;
 
 #[derive(Debug, Clone, serde::Serialize, sqlx::FromRow, ToSchema)]
 #[serde(rename_all = "camelCase")]

--- a/src/server/utilities/bootstrap.rs
+++ b/src/server/utilities/bootstrap.rs
@@ -1,10 +1,11 @@
+use anyhow::anyhow;
+use anyhow::Result;
+use sqlx::PgPool;
+
 use crate::config;
 use crate::server::entities::account::Entity as Account;
 pub use crate::server::middlewares::jwt::Keys as JwtKeys;
 use crate::server::utilities::postgres::Utility as PostgresUtility;
-use anyhow::anyhow;
-use anyhow::Result;
-use sqlx::PgPool;
 
 pub struct Utility;
 

--- a/src/server/utilities/deltalake.rs
+++ b/src/server/utilities/deltalake.rs
@@ -1,4 +1,8 @@
-use crate::config;
+use std::cmp::max;
+use std::cmp::min;
+use std::collections::hash_map::HashMap;
+use std::fmt;
+
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
@@ -8,11 +12,9 @@ use chrono::Utc;
 use deltalake::delta::open_table_with_storage_options;
 use deltalake::delta::DeltaTable;
 use deltalake::schema::SchemaDataType;
-use std::cmp::max;
-use std::cmp::min;
-use std::collections::hash_map::HashMap;
-use std::fmt;
 use utoipa::ToSchema;
+
+use crate::config;
 
 pub type File = deltalake::action::Add;
 

--- a/src/server/utilities/json.rs
+++ b/src/server/utilities/json.rs
@@ -1,9 +1,10 @@
-use crate::server::utilities::deltalake::Stats;
-use crate::server::utilities::deltalake::ValueType;
 use anyhow::anyhow;
 use anyhow::Result;
 use deltalake::schema::Schema;
 use utoipa::ToSchema;
+
+use crate::server::utilities::deltalake::Stats;
+use crate::server::utilities::deltalake::ValueType;
 
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize, strum_macros::EnumString, ToSchema,

--- a/src/server/utilities/signed_url.rs
+++ b/src/server/utilities/signed_url.rs
@@ -1,3 +1,6 @@
+use std::str::FromStr;
+use std::time::Duration;
+
 use anyhow::Context;
 use anyhow::Result;
 use rusoto_core::Region;
@@ -5,8 +8,6 @@ use rusoto_credential::AwsCredentials as AWS;
 use rusoto_s3::util::PreSignedRequest;
 use rusoto_s3::util::PreSignedRequestOption;
 use rusoto_s3::GetObjectRequest;
-use std::str::FromStr;
-use std::time::Duration;
 use tame_gcs::signed_url::SignedUrlOptional;
 use tame_gcs::signed_url::UrlSigner;
 use tame_gcs::signing::ServiceAccount as GCP;

--- a/src/server/utilities/sql.rs
+++ b/src/server/utilities/sql.rs
@@ -1,10 +1,12 @@
-use crate::server::utilities::deltalake::Stats;
-use crate::server::utilities::deltalake::ValueType;
+use std::collections::VecDeque;
+
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use deltalake::schema::Schema;
-use std::collections::VecDeque;
+
+use crate::server::utilities::deltalake::Stats;
+use crate::server::utilities::deltalake::ValueType;
 
 static KEYWORDS: &[char] = &[' ', '=', '\'', '\"', '>', '<'];
 


### PR DESCRIPTION
This PR includes changes from #13, I'll rebase, once that gets merged.

This is a housekeeping PR, which mainly improves the generated OpenApi specification

* to be more in line with the official one
* to be more convenient to use with downstream code generation tools.
  * add explicit operation IDs
  * add tags to distinguish official and delta-sharing-rs specific routes.

I also re-ordered imports according to the as of yet unstable ftm [rule](https://rust-lang.github.io/rustfmt/?version=master&search=import#group_imports).