### PR TITLE
[WIP] Improve authorization flow

### DIFF
--- a/src/server/api_doc.rs
+++ b/src/server/api_doc.rs
@@ -1,5 +1,5 @@
-use crate::server::routers::admin;
-use crate::server::routers::shares;
+use crate::server::routers::catalog;
+use crate::server::routers::sharing;
 use crate::server::services::account;
 use crate::server::services::error;
 use crate::server::services::profile;
@@ -13,22 +13,22 @@ use utoipa::OpenApi;
 #[derive(OpenApi)]
 #[openapi(
     paths(
-        admin::login,
-        admin::profile,
-        admin::accounts::post,
-        admin::accounts::get,
-        admin::accounts::list,
-        admin::shares::post,
-        admin::shares::schemas::post,
-        admin::shares::schemas::tables::post,
-        shares::get,
-        shares::list,
-        shares::all_tables::list,
-        shares::schemas::list,
-        shares::schemas::tables::list,
-        shares::schemas::tables::version::get,
-        shares::schemas::tables::metadata::get,
-        shares::schemas::tables::query::post,
+        catalog::login,
+        catalog::profile,
+        catalog::accounts::post,
+        catalog::accounts::get,
+        catalog::accounts::list,
+        catalog::shares::post,
+        catalog::shares::schemas::post,
+        catalog::shares::schemas::tables::post,
+        sharing::shares::get,
+        sharing::shares::list,
+        sharing::shares::all_tables::list,
+        sharing::shares::schemas::list,
+        sharing::shares::schemas::tables::list,
+        sharing::shares::schemas::tables::version::get,
+        sharing::shares::schemas::tables::metadata::get,
+        sharing::shares::schemas::tables::query::post,
     ),
     components(
 	schemas(
@@ -44,19 +44,19 @@ use utoipa::OpenApi;
 	    json::OpType,
 	    json::PredicateJson
 	),
-        schemas(admin::AdminLoginRequest, admin::AdminLoginResponse, admin::AdminProfileResponse),
-        schemas(admin::accounts::AdminAccountsPostRequest, admin::accounts::AdminAccountsPostResponse),
-        schemas(admin::accounts::AdminAccountsGetResponse),
-        schemas(admin::accounts::AdminAccountsListResponse),
-        schemas(admin::shares::AdminSharesPostRequest, admin::shares::AdminSharesPostResponse),
-        schemas(admin::shares::schemas::AdminSharesSchemasPostRequest, admin::shares::schemas::AdminSharesSchemasPostResponse),
-        schemas(admin::shares::schemas::tables::AdminSharesSchemasTablesPostRequest, admin::shares::schemas::tables::AdminSharesSchemasTablesPostResponse),
-        schemas(shares::SharesGetResponse),
-        schemas(shares::SharesListResponse),
-        schemas(shares::all_tables::SharesAllTablesListResponse),
-        schemas(shares::schemas::SharesSchemasListResponse),
-        schemas(shares::schemas::tables::SharesSchemasTablesListResponse),
-        schemas(shares::schemas::tables::query::SharesSchemasTablesQueryPostRequest),
+        schemas(catalog::CatalogLoginRequest, catalog::CatalogLoginResponse, catalog::CatalogProfileResponse),
+        schemas(catalog::accounts::CatalogAccountsPostRequest, catalog::accounts::CatalogAccountsPostResponse),
+        schemas(catalog::accounts::CatalogAccountsGetResponse),
+        schemas(catalog::accounts::CatalogAccountsListResponse),
+        schemas(catalog::shares::CatalogSharesPostRequest, catalog::shares::CatalogSharesPostResponse),
+        schemas(catalog::shares::schemas::CatalogSharesSchemasPostRequest, catalog::shares::schemas::CatalogSharesSchemasPostResponse),
+        schemas(catalog::shares::schemas::tables::CatalogSharesSchemasTablesPostRequest, catalog::shares::schemas::tables::CatalogSharesSchemasTablesPostResponse),
+        schemas(sharing::shares::SharingSharesGetResponse),
+        schemas(sharing::shares::SharingSharesListResponse),
+        schemas(sharing::shares::all_tables::SharingSharesAllTablesListResponse),
+        schemas(sharing::shares::schemas::SharingSharesSchemasListResponse),
+        schemas(sharing::shares::schemas::tables::SharingSharesSchemasTablesListResponse),
+        schemas(sharing::shares::schemas::tables::query::SharingSharesSchemasTablesQueryPostRequest),
     ),
     tags(
         (name = "Delta Sharing", description = "Delta Sharing API")

--- a/src/server/routers/catalog.rs
+++ b/src/server/routers/catalog.rs
@@ -21,14 +21,14 @@ pub mod shares;
 
 #[derive(serde::Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminLoginRequest {
+pub struct CatalogLoginRequest {
     pub account: String,
     pub password: String,
 }
 
-impl std::fmt::Debug for AdminLoginRequest {
+impl std::fmt::Debug for CatalogLoginRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AdminLoginRequest")
+        f.debug_struct("CatalogLoginRequest")
             .field("account", &self.account)
             .field("password", &"***")
             .finish()
@@ -37,17 +37,17 @@ impl std::fmt::Debug for AdminLoginRequest {
 
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminLoginResponse {
+pub struct CatalogLoginResponse {
     pub profile: Profile,
 }
 
 #[utoipa::path(
     post,
-    path = "/admin/login",
-    tag = "admin",
-    request_body = AdminLoginRequest,
+    path = "/catalog/login",
+    tag = "catalog",
+    request_body = CatalogLoginRequest,
     responses(
-        (status = 200, description = "The profile was successfully returned.", body = AdminLoginResponse),
+        (status = 200, description = "The profile was successfully returned.", body = CatalogLoginResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
         (status = 401, description = "The request is unauthenticated.", body = ErrorMessage),
         (status = 500, description = "The request is not handled correctly due to a server error.", body = ErrorMessage),
@@ -56,7 +56,7 @@ pub struct AdminLoginResponse {
 #[tracing::instrument(skip(state))]
 pub async fn login(
     Extension(state): Extension<SharedState>,
-    Json(payload): Json<AdminLoginRequest>,
+    Json(payload): Json<CatalogLoginRequest>,
 ) -> Result<Response, Error> {
     let Ok(account) = AccountName::new(payload.account) else {
         tracing::error!("requested account data is malformed");
@@ -115,20 +115,21 @@ pub async fn login(
         }
     }
     tracing::info!("profile was successfully returned");
-    Ok((StatusCode::OK, Json(AdminLoginResponse { profile })).into_response())
+    Ok((StatusCode::OK, Json(CatalogLoginResponse { profile })).into_response())
 }
 
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminProfileResponse {
+pub struct CatalogProfileResponse {
     pub profile: Profile,
 }
 
 #[utoipa::path(
     get,
-    path = "/admin/profile",
+    path = "/catalog/profile",
+    tag = "catalog",
     responses(
-        (status = 200, description = "The profile were successfully returned.", body = AdminProfileResponse),
+        (status = 200, description = "The profile were successfully returned.", body = CatalogProfileResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
         (status = 401, description = "The request is unauthenticated. The bearer token is missing or incorrect.", body = ErrorMessage),
         (status = 403, description = "The request is forbidden from being fulfilled.", body = ErrorMessage),
@@ -150,5 +151,5 @@ pub async fn profile(Extension(account): Extension<AccountEntity>) -> Result<Res
         return Err(anyhow!("failed to create profile").into());
     };
     tracing::info!("profile was successfully returned");
-    Ok((StatusCode::OK, Json(AdminProfileResponse { profile })).into_response())
+    Ok((StatusCode::OK, Json(CatalogProfileResponse { profile })).into_response())
 }

--- a/src/server/routers/catalog/accounts.rs
+++ b/src/server/routers/catalog/accounts.rs
@@ -21,7 +21,7 @@ const DEFAULT_PAGE_RESULTS: usize = 10;
 
 #[derive(Debug, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminAccountsPostRequest {
+pub struct CatalogAccountsPostRequest {
     pub id: Option<String>,
     pub name: String,
     pub email: String,
@@ -32,18 +32,18 @@ pub struct AdminAccountsPostRequest {
 
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminAccountsPostResponse {
+pub struct CatalogAccountsPostResponse {
     pub account: Account,
 }
 
 #[utoipa::path(
     post,
-    path = "/admin/accounts",
-    operation_id = "CreateAccount",
-    tag = "admin",
-    request_body = AdminAccountsPostRequest,
+    path = "/catalog/accounts",
+    operation_id = "CatalogCreateAccount",
+    tag = "catalog",
+    request_body = CatalogAccountsPostRequest,
     responses(
-        (status = 201, description = "The account was successfully registered.", body = AdminAccountsPostResponse),
+        (status = 201, description = "The account was successfully registered.", body = CatalogAccountsPostResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
         (status = 401, description = "The request is unauthenticated. The bearer token is missing or incorrect.", body = ErrorMessage),
         (status = 409, description = "The account was already registered.", body = ErrorMessage),
@@ -53,7 +53,7 @@ pub struct AdminAccountsPostResponse {
 #[tracing::instrument(skip(state))]
 pub async fn post(
     Extension(state): Extension<SharedState>,
-    Json(payload): Json<AdminAccountsPostRequest>,
+    Json(payload): Json<CatalogAccountsPostRequest>,
 ) -> Result<Response, Error> {
     let Ok(account) = AccountEntity::new(
         payload.id,
@@ -71,7 +71,7 @@ pub async fn post(
             tracing::info!("account was successfully registered");
             Ok((
                 StatusCode::CREATED,
-                Json(AdminAccountsPostResponse {
+                Json(CatalogAccountsPostResponse {
                     account: Account::from(account),
                 }),
             )
@@ -92,24 +92,24 @@ pub async fn post(
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminAccountsGetParams {
+pub struct CatalogAccountsGetParams {
     account: String,
 }
 
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminAccountsGetResponse {
+pub struct CatalogAccountsGetResponse {
     pub account: Account,
 }
 
 #[utoipa::path(
     get,
-    path = "/admin/accounts/{account}",
-    operation_id = "GetAccount",
-    tag = "admin",
-    params(AdminAccountsGetParams),
+    path = "/catalog/accounts/{account}",
+    operation_id = "CatalogGetAccount",
+    tag = "catalog",
+    params(CatalogAccountsGetParams),
     responses(
-        (status = 200, description = "The account's metadata was successfully returned.", body = AdminAccountsGetResponse),
+        (status = 200, description = "The account's metadata was successfully returned.", body = CatalogAccountsGetResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
         (status = 401, description = "The request is unauthenticated. The bearer token is missing or incorrect.", body = ErrorMessage),
         (status = 403, description = "The request is forbidden from being fulfilled.", body = ErrorMessage),
@@ -120,7 +120,7 @@ pub struct AdminAccountsGetResponse {
 #[tracing::instrument(skip(state))]
 pub async fn get(
     Extension(state): Extension<SharedState>,
-    Path(params): Path<AdminAccountsGetParams>,
+    Path(params): Path<CatalogAccountsGetParams>,
 ) -> Result<Response, Error> {
     let Ok(account) = AccountName::new(params.account) else {
         tracing::error!("requested account data is malformed");
@@ -137,19 +137,19 @@ pub async fn get(
         return Err(Error::NotFound);
     };
     tracing::info!("account's metadata was successfully returned");
-    Ok((StatusCode::OK, Json(AdminAccountsGetResponse { account })).into_response())
+    Ok((StatusCode::OK, Json(CatalogAccountsGetResponse { account })).into_response())
 }
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminAccountsListQuery {
+pub struct CatalogAccountsListQuery {
     pub max_results: Option<i64>,
     pub page_token: Option<String>,
 }
 
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminAccountsListResponse {
+pub struct CatalogAccountsListResponse {
     pub items: Vec<Account>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_page_token: Option<String>,
@@ -157,12 +157,12 @@ pub struct AdminAccountsListResponse {
 
 #[utoipa::path(
     get,
-    path = "/admin/accounts",
-    operation_id = "ListAccounts",
-    tag = "admin",
-    params(AdminAccountsListQuery),
+    path = "/catalog/accounts",
+    operation_id = "CatalogListAccounts",
+    tag = "catalog",
+    params(CatalogAccountsListQuery),
     responses(
-        (status = 200, description = "The accounts were successfully returned.", body = AdminAccountsListResponse),
+        (status = 200, description = "The accounts were successfully returned.", body = CatalogAccountsListResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
         (status = 401, description = "The request is unauthenticated. The bearer token is missing or incorrect.", body = ErrorMessage),
         (status = 403, description = "The request is forbidden from being fulfilled.", body = ErrorMessage),
@@ -172,7 +172,7 @@ pub struct AdminAccountsListResponse {
 #[tracing::instrument(skip(state))]
 pub async fn list(
     Extension(state): Extension<SharedState>,
-    Query(query): Query<AdminAccountsListQuery>,
+    Query(query): Query<CatalogAccountsListQuery>,
 ) -> Result<Response, Error> {
     let limit = if let Some(limit) = &query.max_results {
         let Ok(limit) = usize::try_from(*limit) else {
@@ -202,7 +202,7 @@ pub async fn list(
         tracing::info!("accounts were successfully returned");
         return Ok((
             StatusCode::OK,
-            Json(AdminAccountsListResponse {
+            Json(CatalogAccountsListResponse {
                 items: accounts.to_vec(),
                 next_page_token: next.name.clone().into(),
             }),
@@ -212,7 +212,7 @@ pub async fn list(
     tracing::info!("accounts were successfully returned");
     Ok((
         StatusCode::OK,
-        Json(AdminAccountsListResponse {
+        Json(CatalogAccountsListResponse {
             items: accounts,
             next_page_token: None,
         }),

--- a/src/server/routers/catalog/shares.rs
+++ b/src/server/routers/catalog/shares.rs
@@ -17,24 +17,24 @@ pub mod schemas;
 
 #[derive(Debug, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminSharesPostRequest {
+pub struct CatalogSharesPostRequest {
     pub name: String,
 }
 
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminSharesPostResponse {
+pub struct CatalogSharesPostResponse {
     pub share: Share,
 }
 
 #[utoipa::path(
     post,
-    path = "/admin/shares",
-    operation_id = "CreateShare",
-    tag = "admin",
-    request_body = AdminSharesPostRequest,
+    path = "/catalog/shares",
+    operation_id = "CatalogCreateShare",
+    tag = "catalog",
+    request_body = CatalogSharesPostRequest,
     responses(
-        (status = 201, description = "The share was successfully registered.", body = AdminSharesPostResponse),
+        (status = 201, description = "The share was successfully registered.", body = CatalogSharesPostResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
         (status = 401, description = "The request is unauthenticated. The bearer token is missing or incorrect.", body = ErrorMessage),
         (status = 409, description = "The share was already registered.", body = ErrorMessage),
@@ -45,7 +45,7 @@ pub struct AdminSharesPostResponse {
 pub async fn post(
     Extension(account): Extension<AccountEntity>,
     Extension(state): Extension<SharedState>,
-    Json(payload): Json<AdminSharesPostRequest>,
+    Json(payload): Json<CatalogSharesPostRequest>,
 ) -> Result<Response, Error> {
     let Ok(share) = ShareEntity::new(None, payload.name, account.id().to_string()) else {
         tracing::error!("requested share data is malformed");
@@ -56,7 +56,7 @@ pub async fn post(
             tracing::info!("share was successfully registered");
             Ok((
                 StatusCode::CREATED,
-                Json(AdminSharesPostResponse {
+                Json(CatalogSharesPostResponse {
                     share: Share::from(share),
                 }),
             )

--- a/src/server/routers/catalog/shares/schemas.rs
+++ b/src/server/routers/catalog/shares/schemas.rs
@@ -22,31 +22,31 @@ pub mod tables;
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminSharesSchemasPostParams {
+pub struct CatalogSharesSchemasPostParams {
     share: String,
 }
 
 #[derive(Debug, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminSharesSchemasPostRequest {
+pub struct CatalogSharesSchemasPostRequest {
     pub name: String,
 }
 
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminSharesSchemasPostResponse {
+pub struct CatalogSharesSchemasPostResponse {
     pub schema: Schema,
 }
 
 #[utoipa::path(
     post,
-    path = "/admin/shares/{share}/schemas",
-    operation_id = "CreateSchema",
-    tag = "admin",
-    params(AdminSharesSchemasPostParams),
-    request_body = AdminSharesSchemasPostRequest,
+    path = "/catalog/shares/{share}/schemas",
+    operation_id = "CatalogCreateSchema",
+    tag = "catalog",
+    params(CatalogSharesSchemasPostParams),
+    request_body = CatalogSharesSchemasPostRequest,
     responses(
-        (status = 201, description = "The schema was successfully registered.", body = AdminSharesSchemasPostResponse),
+        (status = 201, description = "The schema was successfully registered.", body = CatalogSharesSchemasPostResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
         (status = 401, description = "The request is unauthenticated. The bearer token is missing or incorrect.", body = ErrorMessage),
         (status = 409, description = "The schema was already registered.", body = ErrorMessage),
@@ -57,8 +57,8 @@ pub struct AdminSharesSchemasPostResponse {
 pub async fn post(
     Extension(account): Extension<AccountEntity>,
     Extension(state): Extension<SharedState>,
-    Path(params): Path<AdminSharesSchemasPostParams>,
-    Json(payload): Json<AdminSharesSchemasPostRequest>,
+    Path(params): Path<CatalogSharesSchemasPostParams>,
+    Json(payload): Json<CatalogSharesSchemasPostRequest>,
 ) -> Result<Response, Error> {
     let Ok(share_name) = ShareName::new(params.share) else {
         tracing::error!("requested share data is malformed");
@@ -92,7 +92,7 @@ pub async fn post(
             tracing::info!("schema was successfully registered");
             Ok((
                 StatusCode::CREATED,
-                Json(AdminSharesSchemasPostResponse {
+                Json(CatalogSharesSchemasPostResponse {
                     schema: Schema::from(schema),
                 }),
             )

--- a/src/server/routers/catalog/shares/schemas/tables.rs
+++ b/src/server/routers/catalog/shares/schemas/tables.rs
@@ -22,33 +22,33 @@ use crate::server::utilities::postgres::Utility as PostgresUtility;
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminSharesSchemasTablesPostParams {
+pub struct CatalogSharesSchemasTablesPostParams {
     share: String,
     schema: String,
 }
 
 #[derive(Debug, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminSharesSchemasTablesPostRequest {
+pub struct CatalogSharesSchemasTablesPostRequest {
     pub name: String,
     pub location: String,
 }
 
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct AdminSharesSchemasTablesPostResponse {
+pub struct CatalogSharesSchemasTablesPostResponse {
     pub table: Table,
 }
 
 #[utoipa::path(
     post,
-    path = "/admin/shares/{share}/schemas/{schema}/tables",
-    operation_id = "CreateTable",
-    tag = "admin",
-    params(AdminSharesSchemasTablesPostParams),
-    request_body = AdminSharesSchemasTablesPostRequest,
+    path = "/catalog/shares/{share}/schemas/{schema}/tables",
+    operation_id = "CatalogCreateTable",
+    tag = "catalog",
+    params(CatalogSharesSchemasTablesPostParams),
+    request_body = CatalogSharesSchemasTablesPostRequest,
     responses(
-        (status = 201, description = "The schema was successfully registered.", body = AdminSharesSchemasTablesPostResponse),
+        (status = 201, description = "The schema was successfully registered.", body = CatalogSharesSchemasTablesPostResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
         (status = 401, description = "The request is unauthenticated. The bearer token is missing or incorrect.", body = ErrorMessage),
         (status = 409, description = "The schema was already registered.", body = ErrorMessage),
@@ -59,8 +59,8 @@ pub struct AdminSharesSchemasTablesPostResponse {
 pub async fn post(
     Extension(account): Extension<AccountEntity>,
     Extension(state): Extension<SharedState>,
-    Path(params): Path<AdminSharesSchemasTablesPostParams>,
-    Json(payload): Json<AdminSharesSchemasTablesPostRequest>,
+    Path(params): Path<CatalogSharesSchemasTablesPostParams>,
+    Json(payload): Json<CatalogSharesSchemasTablesPostRequest>,
 ) -> Result<Response, Error> {
     let Ok(share_name) = ShareName::new(params.share) else {
         tracing::error!("requested share data is malformed");
@@ -110,7 +110,7 @@ pub async fn post(
             tracing::info!("table was successfully registered");
             Ok((
                 StatusCode::CREATED,
-                Json(AdminSharesSchemasTablesPostResponse {
+                Json(CatalogSharesSchemasTablesPostResponse {
                     table: Table::from(table),
                 }),
             )

--- a/src/server/routers/sharing.rs
+++ b/src/server/routers/sharing.rs
@@ -1,0 +1,1 @@
+pub mod shares;

--- a/src/server/routers/sharing/shares.rs
+++ b/src/server/routers/sharing/shares.rs
@@ -22,24 +22,24 @@ const DEFAULT_PAGE_RESULTS: usize = 10;
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct SharesGetParams {
+pub struct SharingSharesGetParams {
     share: String,
 }
 
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct SharesGetResponse {
+pub struct SharingSharesGetResponse {
     pub share: Share,
 }
 
 #[utoipa::path(
     get,
-    path = "/shares/{share}",
-    tag = "official",
-    operation_id = "GetShare",
-    params(SharesGetParams),
+    path = "/sharing/shares/{share}",
+    tag = "sharing",
+    operation_id = "SharingGetShare",
+    params(SharingSharesGetParams),
     responses(
-        (status = 200, description = "The share's metadata was successfully returned.", body = SharesGetResponse),
+        (status = 200, description = "The share's metadata was successfully returned.", body = SharingSharesGetResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
         (status = 401, description = "The request is unauthenticated. The bearer token is missing or incorrect.", body = ErrorMessage),
         (status = 403, description = "The request is forbidden from being fulfilled.", body = ErrorMessage),
@@ -50,7 +50,7 @@ pub struct SharesGetResponse {
 #[tracing::instrument(skip(state))]
 pub async fn get(
     Extension(state): Extension<SharedState>,
-    Path(params): Path<SharesGetParams>,
+    Path(params): Path<SharingSharesGetParams>,
 ) -> Result<Response, Error> {
     let Ok(share) = ShareName::new(params.share) else {
         tracing::error!("requested share data is malformed");
@@ -67,19 +67,19 @@ pub async fn get(
         return Err(Error::NotFound);
     };
     tracing::info!("share's metadata was successfully returned");
-    Ok((StatusCode::OK, Json(SharesGetResponse { share })).into_response())
+    Ok((StatusCode::OK, Json(SharingSharesGetResponse { share })).into_response())
 }
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct SharesListQuery {
+pub struct SharingSharesListQuery {
     pub max_results: Option<i64>,
     pub page_token: Option<String>,
 }
 
 #[derive(serde::Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct SharesListResponse {
+pub struct SharingSharesListResponse {
     pub items: Vec<Share>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_page_token: Option<String>,
@@ -87,12 +87,12 @@ pub struct SharesListResponse {
 
 #[utoipa::path(
     get,
-    path = "/shares",
-    operation_id = "ListShares",
-    tag = "official",
-    params(SharesListQuery),
+    path = "/sharing/shares",
+    operation_id = "SharingListShares",
+    tag = "sharing",
+    params(SharingSharesListQuery),
     responses(
-        (status = 200, description = "The shares were successfully returned.", body = SharesListResponse),
+        (status = 200, description = "The shares were successfully returned.", body = SharingSharesListResponse),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
         (status = 401, description = "The request is unauthenticated. The bearer token is missing or incorrect.", body = ErrorMessage),
         (status = 403, description = "The request is forbidden from being fulfilled.", body = ErrorMessage),
@@ -102,7 +102,7 @@ pub struct SharesListResponse {
 #[tracing::instrument(skip(state))]
 pub async fn list(
     Extension(state): Extension<SharedState>,
-    Query(query): Query<SharesListQuery>,
+    Query(query): Query<SharingSharesListQuery>,
 ) -> Result<Response, Error> {
     let limit = if let Some(limit) = &query.max_results {
         let Ok(limit) = usize::try_from(*limit) else {
@@ -132,7 +132,7 @@ pub async fn list(
         tracing::info!("shares were successfully returned");
         return Ok((
             StatusCode::OK,
-            Json(SharesListResponse {
+            Json(SharingSharesListResponse {
                 items: shares.to_vec(),
                 next_page_token: next.name.clone().into(),
             }),
@@ -142,7 +142,7 @@ pub async fn list(
     tracing::info!("shares were successfully returned");
     Ok((
         StatusCode::OK,
-        Json(SharesListResponse {
+        Json(SharingSharesListResponse {
             items: shares,
             next_page_token: None,
         }),

--- a/src/server/routers/sharing/shares/schemas/tables/metadata.rs
+++ b/src/server/routers/sharing/shares/schemas/tables/metadata.rs
@@ -23,7 +23,7 @@ const HEADER_NAME: &str = "Delta-Table-Version";
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct SharesSchemasTablesMetadataGetParams {
+pub struct SharingSharesSchemasTablesMetadataGetParams {
     share: String,
     schema: String,
     table: String,
@@ -31,10 +31,10 @@ pub struct SharesSchemasTablesMetadataGetParams {
 
 #[utoipa::path(
     get,
-    path = "/shares/{share}/schemas/{schema}/tables/{table}/metadata",
-    operation_id = "GetTableMetadata",
-    tag = "official",
-    params(SharesSchemasTablesMetadataGetParams),
+    path = "/sharing/shares/{share}/schemas/{schema}/tables/{table}/metadata",
+    operation_id = "SharingGetTableMetadata",
+    tag = "sharing",
+    params(SharingSharesSchemasTablesMetadataGetParams),
     responses(
         (status = 200, description = "The table metadata was successfully returned.", body = String),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
@@ -47,7 +47,7 @@ pub struct SharesSchemasTablesMetadataGetParams {
 #[tracing::instrument(skip(state))]
 pub async fn get(
     Extension(state): Extension<SharedState>,
-    Path(params): Path<SharesSchemasTablesMetadataGetParams>,
+    Path(params): Path<SharingSharesSchemasTablesMetadataGetParams>,
 ) -> Result<Response, Error> {
     let Ok(share) = ShareName::new(params.share) else {
         tracing::error!("requested share data is malformed");

--- a/src/server/routers/sharing/shares/schemas/tables/query.rs
+++ b/src/server/routers/sharing/shares/schemas/tables/query.rs
@@ -34,7 +34,7 @@ const HEADER_NAME: &str = "Delta-Table-Version";
 
 #[derive(Debug, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct SharesSchemasTablesQueryPostRequest {
+pub struct SharingSharesSchemasTablesQueryPostRequest {
     pub predicate_hints: Option<Vec<String>>,
     pub json_predicate_hints: Option<PredicateJson>,
     pub limit_hint: Option<i32>,
@@ -44,7 +44,7 @@ pub struct SharesSchemasTablesQueryPostRequest {
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct SharesSchemasTablesQueryPostParams {
+pub struct SharingSharesSchemasTablesQueryPostParams {
     share: String,
     schema: String,
     table: String,
@@ -52,11 +52,11 @@ pub struct SharesSchemasTablesQueryPostParams {
 
 #[utoipa::path(
     post,
-    path = "/shares/{share}/schemas/{schema}/tables/{table}/query",
-    operation_id = "QueryTable",
-    tag = "official",
-    request_body = SharesSchemasTablesQueryPostRequest,
-    params(SharesSchemasTablesQueryPostParams),
+    path = "/sharing/shares/{share}/schemas/{schema}/tables/{table}/query",
+    operation_id = "SharingQueryTable",
+    tag = "sharing",
+    request_body = SharingSharesSchemasTablesQueryPostRequest,
+    params(SharingSharesSchemasTablesQueryPostParams),
     responses(
         (status = 200, description = "The tables were successfully returned.", body = String),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
@@ -69,8 +69,8 @@ pub struct SharesSchemasTablesQueryPostParams {
 #[tracing::instrument(skip(state))]
 pub async fn post(
     Extension(state): Extension<SharedState>,
-    Path(params): Path<SharesSchemasTablesQueryPostParams>,
-    Json(payload): Json<SharesSchemasTablesQueryPostRequest>,
+    Path(params): Path<SharingSharesSchemasTablesQueryPostParams>,
+    Json(payload): Json<SharingSharesSchemasTablesQueryPostRequest>,
 ) -> Result<Response, Error> {
     let predicate_hints = if let Some(predicate_hints) = payload.predicate_hints {
         let predicate_hints: Result<Vec<SQLPartitionFilter>, _> = predicate_hints

--- a/src/server/routers/sharing/shares/schemas/tables/version.rs
+++ b/src/server/routers/sharing/shares/schemas/tables/version.rs
@@ -20,7 +20,7 @@ const HEADER_NAME: &str = "Delta-Table-Version";
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct SharesSchemasTablesVersionGetParams {
+pub struct SharingSharesSchemasTablesVersionGetParams {
     share: String,
     schema: String,
     table: String,
@@ -28,16 +28,16 @@ pub struct SharesSchemasTablesVersionGetParams {
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
 #[serde(rename_all = "camelCase")]
-pub struct SharesSchemasTablesVersionGetQuery {
+pub struct SharingSharesSchemasTablesVersionGetQuery {
     pub starting_timestamp: Option<String>,
 }
 
 #[utoipa::path(
     get,
-    path = "/shares/{share}/schemas/{schema}/tables/{table}/version",
-    operation_id = "GetTableVersion",
-    tag = "official",
-    params(SharesSchemasTablesVersionGetParams),
+    path = "/sharing/shares/{share}/schemas/{schema}/tables/{table}/version",
+    operation_id = "SharingGetTableVersion",
+    tag = "sharing",
+    params(SharingSharesSchemasTablesVersionGetParams),
     responses(
         (status = 200, description = "The table version was successfully returned."),
         (status = 400, description = "The request is malformed.", body = ErrorMessage),
@@ -50,8 +50,8 @@ pub struct SharesSchemasTablesVersionGetQuery {
 #[tracing::instrument(skip(state))]
 pub async fn get(
     Extension(state): Extension<SharedState>,
-    Path(params): Path<SharesSchemasTablesVersionGetParams>,
-    Query(query): Query<SharesSchemasTablesVersionGetQuery>,
+    Path(params): Path<SharingSharesSchemasTablesVersionGetParams>,
+    Query(query): Query<SharingSharesSchemasTablesVersionGetQuery>,
 ) -> Result<Response, Error> {
     let starting_timestamp = if let Some(starting_timestamp) = &query.starting_timestamp {
         let Ok(starting_timestamp) =


### PR DESCRIPTION
The authentication process should be handled in the front end and BFF, so the admin/auth middleware should be switched based on the feature flag to enable or disable it:

https://medium.com/@ognis1205/deltahub-data-sharing-platform-1-bdee60e74245

TODO:

  - [x] refactor backend URLs, e.g., admin/ -> catalog/, delta-sharing-related APIs -> under sharing/
  - [ ] switching auth middleware based on the feature flag
  - [x] rename Admin -> Catalog
  - [ ] refactor DB schema, e.g., password on account table should be optional

The entire PR is going to be large, so I will follow the WIP pattern to reduce the load of the upcoming PRs. Therefore, this PR is marked as WIP just for sharing the context of the implementation. Any feedbacks including the options against the implementation would be welcome.

@roeap @rtyler 