### PR TITLE
ShareStore extension

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,5 @@
 mod api_doc;
+mod catalog;
 mod entities;
 mod middlewares;
 mod repositories;

--- a/src/server/catalog/file/example-shares.yml
+++ b/src/server/catalog/file/example-shares.yml
@@ -1,0 +1,38 @@
+shares:
+  - name: "share1"
+    schemas:
+      - name: "schema1"
+        tables:
+          - name: "table1"
+            # S3. See https://github.com/delta-io/delta-sharing#s3 for how to config the credentials
+            location: "s3a://<bucket-name>/<the-table-path>"
+            id: "00000000-0000-0000-0000-000000000000"
+          - name: "table2"
+            # Azure Blob Storage. See https://github.com/delta-io/delta-sharing#azure-blob-storage for how to config the credentials
+            location: "wasbs://<container-name>@<account-name}.blob.core.windows.net/<the-table-path>"
+            id: "00000000-0000-0000-0000-000000000001"
+  - name: "share2"
+    schemas:
+      - name: "schema2"
+        tables:
+          - name: "table3"
+            # Azure Data Lake Storage Gen2. See https://github.com/delta-io/delta-sharing#azure-data-lake-storage-gen2 for how to config the credentials
+            location: "abfss://<container-name>@<account-name}.dfs.core.windows.net/<the-table-path>"
+            historyShared: true
+            id: "00000000-0000-0000-0000-000000000002"
+  - name: "share3"
+    schemas:
+      - name: "schema3"
+        tables:
+          - name: "table4"
+            # Google Cloud Storage (GCS). See https://github.com/delta-io/delta-sharing#google-cloud-storage for how to config the credentials
+            location: "gs://<bucket-name>/<the-table-path>"
+            id: "00000000-0000-0000-0000-000000000003"
+  - name: "share4"
+    schemas:
+      - name: "schema4"
+        tables:
+          - name: "table5"
+            # Cloudflare R2. See https://github.com/delta-io/delta-sharing#cloudflare-r2 for how to config the credentials
+            location: "s3a://<bucket-name>/<the-table-path>"
+            id: "00000000-0000-0000-0000-000000000004"

--- a/src/server/catalog/file/mod.rs
+++ b/src/server/catalog/file/mod.rs
@@ -1,0 +1,215 @@
+use serde::Deserialize;
+use std::path::Path;
+
+use crate::server::services::{error::Error, schema::Schema, share::Share, table::Table};
+
+use super::{Page, Pagination, ShareStore};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize)]
+struct ShareFile {
+    shares: Vec<RawShare>,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize)]
+struct RawShare {
+    name: String,
+    schemas: Vec<RawSchema>,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize)]
+struct RawSchema {
+    name: String,
+    tables: Vec<RawTable>,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize)]
+struct RawTable {
+    name: String,
+    location: String,
+    id: String,
+}
+
+#[derive(Debug)]
+pub struct YamlShareStore {
+    store: ShareFile,
+}
+
+impl YamlShareStore {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn std::error::Error>> {
+        let file = std::fs::File::open(path)?;
+        let shares: ShareFile = serde_yaml::from_reader(file)?;
+        let yss = YamlShareStore { store: shares };
+        Ok(yss)
+    }
+}
+
+#[async_trait::async_trait]
+impl ShareStore for YamlShareStore {
+    async fn list_shares(&self, _pagination: &Pagination) -> Result<Page<Share>, Error> {
+        let shares = self
+            .store
+            .shares
+            .iter()
+            .map(|s| Share {
+                id: s.name.clone(),
+                name: s.name.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        Ok(Page {
+            items: shares,
+            next_page_token: None,
+        })
+    }
+
+    async fn get_share(&self, name: &str) -> Result<Option<Share>, Error> {
+        let share = self
+            .store
+            .shares
+            .iter()
+            .find(|s| s.name == name)
+            .map(|s| Share {
+                id: s.name.clone(),
+                name: s.name.clone(),
+            });
+
+        Ok(share)
+    }
+
+    async fn list_schemas(
+        &self,
+        share: &str,
+        _pagination: &Pagination,
+    ) -> Result<Page<Schema>, Error> {
+        let share = self
+            .store
+            .shares
+            .iter()
+            .find(|s| s.name == share)
+            .ok_or_else(|| Error::NotFound)?;
+
+        let schemas = share
+            .schemas
+            .iter()
+            .map(|s| Schema {
+                id: s.name.clone(),
+                name: s.name.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        Ok(Page {
+            items: schemas,
+            next_page_token: None,
+        })
+    }
+
+    async fn list_tables_in_share(
+        &self,
+        share: &str,
+        _pagination: &Pagination,
+    ) -> Result<Page<Table>, Error> {
+        let share = self
+            .store
+            .shares
+            .iter()
+            .find(|s| s.name == share)
+            .ok_or_else(|| Error::NotFound)?;
+
+        let tables = share
+            .schemas
+            .iter()
+            .flat_map(|s| {
+                s.tables
+                    .iter()
+                    .map(|t| Table {
+                        id: t.id.clone(),
+                        name: t.name.clone(),
+                        location: t.location.clone(),
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        Ok(Page {
+            items: tables,
+            next_page_token: None,
+        })
+    }
+
+    async fn list_tables_in_schema(
+        &self,
+        share: &str,
+        schema: &str,
+        _pagination: &Pagination,
+    ) -> Result<Page<Table>, Error> {
+        let share = self
+            .store
+            .shares
+            .iter()
+            .find(|s| s.name == share)
+            .ok_or_else(|| Error::NotFound)?;
+
+        let schema = share
+            .schemas
+            .iter()
+            .find(|s| s.name == schema)
+            .ok_or_else(|| Error::NotFound)?;
+
+        let tables = schema
+            .tables
+            .iter()
+            .map(|t| Table {
+                id: t.id.clone(),
+                name: t.name.clone(),
+                location: t.location.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        Ok(Page {
+            items: tables,
+            next_page_token: None,
+        })
+    }
+
+    async fn get_table(&self, share: &str, schema: &str, table: &str) -> Result<Table, Error> {
+        let share = self
+            .store
+            .shares
+            .iter()
+            .find(|s| s.name == share)
+            .ok_or_else(|| Error::NotFound)?;
+
+        let schema = share
+            .schemas
+            .iter()
+            .find(|s| s.name == schema)
+            .ok_or_else(|| Error::NotFound)?;
+
+        let table = schema
+            .tables
+            .iter()
+            .find(|t| t.name == table)
+            .ok_or_else(|| Error::NotFound)?;
+
+        Ok(Table {
+            id: table.id.clone(),
+            name: table.name.clone(),
+            location: table.location.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_list_shares() {
+        let yss =
+            YamlShareStore::from_file("./src/server/catalog/file/example-shares.yml").unwrap();
+        let shares = yss.list_shares(&Pagination::default()).await.unwrap();
+
+        assert_eq!(shares.items.len(), 4);
+        assert_eq!(shares.next_page_token, None);
+    }
+}

--- a/src/server/catalog/mod.rs
+++ b/src/server/catalog/mod.rs
@@ -1,0 +1,63 @@
+use super::services::{error::Error, schema::Schema, share::Share, table::Table};
+
+mod file;
+mod postgres;
+
+#[async_trait::async_trait]
+pub trait ShareStore: Send + Sync {
+    async fn list_shares(&self, pagination: &Pagination) -> Result<Page<Share>, Error>;
+
+    async fn get_share(&self, name: &str) -> Result<Option<Share>, Error>;
+
+    async fn list_schemas(
+        &self,
+        share: &str,
+        pagination: &Pagination,
+    ) -> Result<Page<Schema>, Error>;
+
+    async fn list_tables_in_share(
+        &self,
+        share: &str,
+        pagination: &Pagination,
+    ) -> Result<Page<Table>, Error>;
+
+    async fn list_tables_in_schema(
+        &self,
+        share: &str,
+        schema: &str,
+        pagination: &Pagination,
+    ) -> Result<Page<Table>, Error>;
+
+    async fn get_table(&self, share: &str, schema: &str, table: &str) -> Result<Table, Error>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Pagination {
+    max_results: Option<u32>,
+    page_token: Option<String>,
+}
+
+impl Pagination {
+    pub fn max_results(&self) -> Option<u32> {
+        self.max_results
+    }
+
+    pub fn page_token(&self) -> Option<&str> {
+        self.page_token.as_deref()
+    }
+}
+
+pub struct Page<T> {
+    items: Vec<T>,
+    next_page_token: Option<String>,
+}
+
+impl<T> Page<T> {
+    pub fn items(&self) -> &[T] {
+        &self.items
+    }
+
+    pub fn next_page_token(&self) -> Option<&str> {
+        self.next_page_token.as_deref()
+    }
+}

--- a/src/server/catalog/postgres/mod.rs
+++ b/src/server/catalog/postgres/mod.rs
@@ -1,0 +1,124 @@
+use anyhow::{Context, Result};
+use sqlx::{Execute, PgPool, Postgres, QueryBuilder};
+
+use crate::server::services::{error::Error, schema::Schema, share::Share, table::Table};
+
+use super::{Page, Pagination, ShareStore};
+
+pub struct PostgresShareStore {
+    pool: PgPool,
+}
+
+impl PostgresShareStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn query(&self, limit: Option<u32>, after: Option<&str>) -> Result<Vec<Share>> {
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .context("failed to acquire postgres connection")?;
+        let mut builder: QueryBuilder<'_, Postgres> = QueryBuilder::new(
+            "SELECT
+                 id::text,
+                 name
+             FROM share",
+        );
+        if let Some(name) = after {
+            builder.push(" WHERE name >= ");
+            builder.push_bind(name);
+        }
+        builder.push(" ORDER BY name ");
+        if let Some(limit) = limit {
+            builder.push(" LIMIT ");
+            builder.push_bind(limit as i32);
+        }
+        let mut query = sqlx::query_as::<_, Share>(builder.build().sql());
+        if let Some(name) = after {
+            query = query.bind(name);
+        }
+        if let Some(limit) = limit {
+            query = query.bind(limit as i32);
+        }
+        let rows: Vec<Share> = query
+            .fetch_all(&mut *conn)
+            .await
+            .context("failed to list shares from [share]")?;
+        Ok(rows)
+    }
+
+    pub async fn query_by_name(&self, name: &str) -> Result<Option<Share>> {
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .context("failed to acquire postgres connection")?;
+        let row: Option<Share> = sqlx::query_as::<_, Share>(
+            "SELECT
+                 id::text,
+                 name
+             FROM share
+             WHERE name = $1",
+        )
+        .bind(name)
+        .fetch_optional(&mut *conn)
+        .await
+        .context(format!(r#"failed to select "{}" from [share]"#, name))?;
+        Ok(row)
+    }
+}
+
+#[async_trait::async_trait]
+impl ShareStore for PostgresShareStore {
+    async fn list_shares(&self, pagination: &Pagination) -> Result<Page<Share>, Error> {
+        let limit = pagination.max_results().unwrap_or(500);
+        let after = pagination.page_token();
+
+        let shares = self.query(Some(limit), after).await?;
+        let next = if shares.len() < limit as usize {
+            None
+        } else {
+            shares.last().map(|s| s.name.clone())
+        };
+
+        Ok(Page {
+            items: shares,
+            next_page_token: next,
+        })
+    }
+
+    async fn get_share(&self, name: &str) -> Result<Option<Share>, Error> {
+        unimplemented!()
+    }
+
+    async fn list_schemas(
+        &self,
+        share: &str,
+        pagination: &Pagination,
+    ) -> Result<Page<Schema>, Error> {
+        unimplemented!()
+    }
+
+    async fn list_tables_in_share(
+        &self,
+        share: &str,
+        pagination: &Pagination,
+    ) -> Result<Page<Table>, Error> {
+        unimplemented!()
+    }
+
+    async fn list_tables_in_schema(
+        &self,
+        share: &str,
+        schema: &str,
+        pagination: &Pagination,
+    ) -> Result<Page<Table>, Error> {
+        unimplemented!()
+    }
+
+    async fn get_table(&self, share: &str, schema: &str, table: &str) -> Result<Table, Error> {
+        unimplemented!()
+    }
+}

--- a/src/server/routers.rs
+++ b/src/server/routers.rs
@@ -23,8 +23,33 @@ use crate::server::api_doc::ApiDoc;
 use crate::server::middlewares::jwt;
 use crate::server::services::error::Error;
 
+use super::services::share::Share;
+
+pub struct Pagination {
+    max_results: Option<u32>,
+    page_token: Option<String>,
+}
+
+pub struct Page<T> {
+    items: Vec<T>,
+    next_page_token: Option<String>,
+}
+
+pub trait ShareStore: Send + Sync {
+    fn list(&self, pagination: &Pagination) -> Result<Page<Share>>;
+}
+
+pub struct DefaultShareStore;
+
+impl ShareStore for DefaultShareStore {
+    fn list(&self, pagination: &Pagination) -> Result<Page<Share>> {
+        unimplemented!()
+    }
+}
+
 pub struct State {
     pub pg_pool: PgPool,
+    pub state_store: Arc<dyn ShareStore>,
     pub gcp_service_account: Option<ServiceAccount>,
     pub aws_credentials: Option<AwsCredentials>,
     pub azure_credentials: Option<StorageCredentials>,
@@ -44,6 +69,7 @@ async fn route(
 ) -> Result<Router> {
     let state = Arc::new(State {
         pg_pool,
+        state_store: Arc::new(DefaultShareStore),
         gcp_service_account,
         aws_credentials,
         azure_credentials,


### PR DESCRIPTION
The `ShareStore` trait is used to list shares/schemas/tables and get the table storage location.

In this PR we introduce two implementations of this trait. One based on a Postgres database, one based on a YAML file. 

Closes #31 