### PR TITLE
ci: update github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,42 +2,57 @@ name: Report a bug
 description: File a bug report
 title: "[Bug]: "
 labels: ["bug"]
-assignees:
-  - octocat
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
-  - type: textarea
-    id: what-happened
+        Thanks for taking the time to help us improve.
+  - type: checkboxes
     attributes:
-      label: What happened?
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
-      value: "A bug happened!"
-    validations:
-      required: true
-  - type: dropdown
-    id: version
-    attributes:
-      label: Version
-      description: What version of our software are you running?
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
       options:
-        - 0.1.0 (Default)
+      - label: I have searched the existing issues
+        required: true
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        examples:
+          - **OS**: Ubuntu 20.04
+          - **version**: 0.1.3
+          - **rust**: 1.77
+      value: |
+          - OS:
+          - version:
+          - rust:
+      render: markdown
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
     validations:
       required: true
   - type: textarea
-    id: logs
+    id: reproduce
     attributes:
-      label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: Shell
+      label: To Reproduce
+      description: Steps to reproduce the behavior.
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
   - type: checkboxes
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/delta-incubator/delta-sharing-rs#coc-ov-file)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,37 +1,43 @@
 name: Request a new feature
 description: File a feature request
-title: "[Tool, Solution, or Feature Name]: "
+title: "[Feature]: "
 labels: ["enhancement"]
-assignees:
-  - octocat
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this feature request!
+        Thanks for taking the time to help us improve!
   - type: textarea
     id: problem
     attributes:
-      label: Is your feature request related to a problem? Please describe.
-      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-      placeholder: Tell us what happened!
-      value: "A problem occured!"
+      label: Problem description
+      description: Is your feature request related to a problem or challenge? Please describe what you are trying to do.
+      placeholder: |
+        A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+        (This section helps developers understand the context and *why* for this feature, in addition to  the *what*)
     validations:
-      required: false
+      required: true
   - type: textarea
     id: solution
     attributes:
-      label: Describe the solution you'd like.
-      description: A clear and concise description of what you want to happen.
-      placeholder: Tell us what you expect!
-      value: "I want this feature!"
+      label: Solution
+      description: Tell us what you expect to happen.
+      placeholder: A clear and concise description of what you want to happen.
     validations:
       required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternative solutions
+      description: Describe alternatives you've considered.
+      placeholder: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
   - type: checkboxes
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/delta-incubator/delta-sharing-rs#coc-ov-file)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+### Which issue does this PR close?
+
+<!--
+We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
+-->
+
+Closes #.
+
+### Rationale for this change
+
+<!--
+Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
+Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
+-->
+
+### Changes are included in this PR
+
+<!--
+There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
+-->
+
+### Are there any user-facing changes?
+
+<!--
+If there are user-facing changes then we may require documentation to be updated before approving the PR.
+-->
+
+<!---
+If there are any breaking changes to public APIs, please add the `breaking change` label.
+-->


### PR DESCRIPTION
the current github templates seemed to be taken from the github  docs without much changes. This updates the templates to be a bit more specific to this project.