### PR TITLE
ci: use latest osx runners

### DIFF
--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -1,7 +1,8 @@
 name: Assign the issue to self
 on:
   issue_comment:
-    types: created
+    types:
+      - created
 
 permissions:
   issues: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
+          - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
 
@@ -56,7 +56,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
+          - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
 
@@ -83,8 +83,6 @@ jobs:
         run: cargo test --lib
 
   integration:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION
### Which issue does this PR close?

osx-11 runners are deprecated, so using the latest runners.
